### PR TITLE
Add basic CI and smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Install package
+        run: |
+          pip install -U pip
+          pip install .
+      - name: Run tests
+        run: pytest -v

--- a/properr/__init__.py
+++ b/properr/__init__.py
@@ -1,7 +1,7 @@
 from importlib import import_module
 
-# Import the Rust extension module
-_rust = import_module("_properr")
+# Import the Rust extension module packaged inside this package
+_rust = import_module("._properr", package=__name__)
 
 # Re-export functions from Rust
 add = _rust.add

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,5 +13,6 @@ authors = [{name = "Properr Developers", email = "devs@example.com"}]
 
 [tool.maturin]
 bindings = "pyo3"
-module-name = "_properr"
+# Install the extension inside the Python package
+module-name = "properr._properr"
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,4 @@
+import properr
+
+def test_add():
+    assert properr.add(1.0, 2.0) == 3.0


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and run tests
- include the Python package when building with maturin
- fix package import path
- add simple pytest smoke test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f16c065883298fcdd42796e5accf