### PR TITLE
Implement basic uncertain value arithmetic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
 name = "properr"
 version = "0.1.0"
 dependencies = [
+ "once_cell",
  "pyo3",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.19", features = ["extension-module"] }
+once_cell = "1"

--- a/properr/__init__.py
+++ b/properr/__init__.py
@@ -5,5 +5,9 @@ _rust = import_module("._properr", package=__name__)
 
 # Re-export functions from Rust
 add = _rust.add
+uval = _rust.uval
+nominal = _rust.nominal
+stddev = _rust.stddev
+UncertainValue = _rust.UncertainValue
 
-__all__ = ["add"]
+__all__ = ["add", "uval", "nominal", "stddev", "UncertainValue"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,110 @@
 use pyo3::prelude::*;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use once_cell::sync::Lazy;
+
+/// Global counter for assigning unique variable ids
+static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+/// Mapping of variable id to its associated standard deviation
+static SIGMAS: Lazy<Mutex<HashMap<u64, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Representation of a value with uncertainty
+#[pyclass]
+#[derive(Clone)]
+struct UncertainValue {
+    nominal: f64,
+    derivatives: HashMap<u64, f64>,
+}
+
+impl UncertainValue {
+    fn combine(
+        left: &HashMap<u64, f64>,
+        right: &HashMap<u64, f64>,
+        right_sign: f64,
+    ) -> HashMap<u64, f64> {
+        let mut out = left.clone();
+        for (k, v) in right {
+            *out.entry(*k).or_insert(0.0) += right_sign * v;
+        }
+        out
+    }
+
+    fn add_internal(&self, other: &UncertainValue) -> UncertainValue {
+        UncertainValue {
+            nominal: self.nominal + other.nominal,
+            derivatives: Self::combine(&self.derivatives, &other.derivatives, 1.0),
+        }
+    }
+
+    fn sub_internal(&self, other: &UncertainValue) -> UncertainValue {
+        UncertainValue {
+            nominal: self.nominal - other.nominal,
+            derivatives: Self::combine(&self.derivatives, &other.derivatives, -1.0),
+        }
+    }
+
+    fn stddev_internal(&self) -> f64 {
+        let sigmas = SIGMAS.lock().unwrap();
+        let mut var: f64 = 0.0;
+        for (id, deriv) in &self.derivatives {
+            if let Some(sigma) = sigmas.get(id) {
+                var += deriv * deriv * sigma * sigma;
+            }
+        }
+        var.sqrt()
+    }
+}
 
 #[pyfunction]
 fn add(a: f64, b: f64) -> f64 {
     a + b
 }
 
+#[pyfunction]
+fn uval(nominal: f64, sigma: f64) -> PyResult<UncertainValue> {
+    let id = NEXT_ID.fetch_add(1, Ordering::SeqCst);
+    SIGMAS.lock().unwrap().insert(id, sigma);
+    let mut d = HashMap::new();
+    d.insert(id, 1.0);
+    Ok(UncertainValue { nominal, derivatives: d })
+}
+
+#[pyfunction]
+fn nominal(v: &UncertainValue) -> f64 {
+    v.nominal
+}
+
+#[pyfunction]
+fn stddev(v: &UncertainValue) -> PyResult<f64> {
+    Ok(v.stddev_internal())
+}
+
+#[pymethods]
+impl UncertainValue {
+    fn nominal(&self) -> f64 {
+        self.nominal
+    }
+
+    fn stddev(&self) -> f64 {
+        self.stddev_internal()
+    }
+
+    fn __add__(&self, other: &UncertainValue) -> UncertainValue {
+        self.add_internal(other)
+    }
+
+    fn __sub__(&self, other: &UncertainValue) -> UncertainValue {
+        self.sub_internal(other)
+    }
+}
+
 #[pymodule]
 fn _properr(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(add, m)?)?;
+    m.add_function(wrap_pyfunction!(uval, m)?)?;
+    m.add_function(wrap_pyfunction!(nominal, m)?)?;
+    m.add_function(wrap_pyfunction!(stddev, m)?)?;
+    m.add_class::<UncertainValue>()?;
     Ok(())
 }

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,4 +1,14 @@
 import properr
+import pytest
 
-def test_add():
-    assert properr.add(1.0, 2.0) == 3.0
+
+def test_uncertain_arithmetic():
+    x = properr.uval(10.0, 1.0)
+    y = properr.uval(10.0, 1.0)
+
+    z = x - y
+    z2 = x - x
+
+    assert properr.nominal(z) == 0.0
+    assert properr.stddev(z) == pytest.approx(2 ** 0.5)
+    assert properr.stddev(z2) == 0.0


### PR DESCRIPTION
## Summary
- create `UncertainValue` type in Rust with derivative tracking
- add `uval`, `nominal`, and `stddev` functions
- expose operator overloading for addition and subtraction
- export the new features from the Python package
- test simple uncertainty propagation

## Testing
- `maturin build --release -q`
- `pip install target/wheels/properr-0.1.0-cp312-cp312-manylinux_2_34_x86_64.whl --force-reinstall --no-deps -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880f377f8008329a0157a8d2386da1d