### PR TITLE
Implement multiplication of UncertainValue

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,14 @@ impl std::ops::Sub for &UncertainValue {
     }
 }
 
+impl std::ops::Mul for &UncertainValue {
+    type Output = UncertainValue;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        self.mul(rhs)
+    }
+}
+
 impl UncertainValue {
     /// Nominal value of this quantity
     pub fn nominal(&self) -> f64 {
@@ -118,7 +126,8 @@ impl UncertainValue {
         self.sub_internal(other)
     }
 
-    fn __mul__(&self, other: &UncertainValue) -> UncertainValue {
+    /// Multiply two uncertain values
+    pub fn mul(&self, other: &UncertainValue) -> UncertainValue {
         self.mul_internal(other)
     }
 }
@@ -160,6 +169,10 @@ impl UncertainValue {
 
     fn __sub__(&self, other: &UncertainValue) -> UncertainValue {
         self.sub(other)
+    }
+
+    fn __mul__(&self, other: &UncertainValue) -> UncertainValue {
+        self.mul(other)
     }
 }
 


### PR DESCRIPTION
## Summary
- expose multiplication through Rust `Mul` trait
- provide `mul()` method and Python `__mul__` binding
- update tests (none) and ensure CI passes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688103e9644c83298391e83e19f77a6d