### PR TITLE
Add division operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,4 +58,4 @@ assert z.nominal() == 5.0
 ## Current Functionality
 
 - Scalar uncertain values (`uval`) with automatic correlation tracking
-- Addition, subtraction, and multiplication of `UncertainValue` instances
+- Addition, subtraction, multiplication, and division of `UncertainValue` instances

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -8,3 +8,10 @@ fn basic_arithmetic() {
     assert_eq!(z.nominal(), 2.0);
 }
 
+#[test]
+fn division_cancels_uncertainty() {
+    let x = UncertainValue::new(3.0, 1.0);
+    let y = &x / &x;
+    assert_eq!(y.nominal(), 1.0);
+    assert_eq!(y.stddev(), 0.0);
+}

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -28,3 +28,16 @@ def test_uncertain_multiplication():
     assert properr.nominal(z) == 100.0
     assert properr.stddev(z) == pytest.approx((200) ** 0.5)
     assert properr.stddev(z2) == pytest.approx(20.0)
+
+
+def test_uncertain_division():
+    x = properr.uval(10.0, 1.0)
+    y = properr.uval(2.0, 0.2)
+
+    z = x / y
+    z2 = x / x
+
+    assert properr.nominal(z) == 5.0
+    assert properr.stddev(z) == pytest.approx(0.5 ** 0.5)
+    assert properr.nominal(z2) == 1.0
+    assert properr.stddev(z2) == 0.0


### PR DESCRIPTION
## Summary
- implement `/` for `UncertainValue`
- expose `__truediv__` to Python
- add tests for division in Rust and Python
- document division in README

## Testing
- `pip install -e .[test]`
- `pytest -q`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68810553c4c083299e4e2e03d203b2aa