### PR TITLE
Add cosine propagation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ assert z.nominal() == 5.0
 - Scalar uncertain values (`uval`) with automatic correlation tracking
 - Addition, subtraction, multiplication, and division of `UncertainValue` instances
 - Propagation through the sine function
+- Propagation through the cosine function

--- a/properr/__init__.py
+++ b/properr/__init__.py
@@ -8,6 +8,7 @@ uval = _rust.uval
 nominal = _rust.nominal
 stddev = _rust.stddev
 sin = _rust.sin
+cos = _rust.cos
 UncertainValue = _rust.UncertainValue
 
-__all__ = ["uval", "nominal", "stddev", "sin", "UncertainValue"]
+__all__ = ["uval", "nominal", "stddev", "sin", "cos", "UncertainValue"]

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -23,3 +23,11 @@ fn sine_propagates_uncertainty() {
     assert_eq!(y.nominal(), 0.0);
     assert_eq!(y.stddev(), 1.0);
 }
+
+#[test]
+fn cosine_propagates_uncertainty() {
+    let x = UncertainValue::new(0.0, 1.0);
+    let y = x.cos();
+    assert_eq!(y.nominal(), 1.0);
+    assert_eq!(y.stddev(), 0.0);
+}

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -49,3 +49,11 @@ def test_uncertain_sine():
 
     assert properr.nominal(y) == 0.0
     assert properr.stddev(y) == 1.0
+
+
+def test_uncertain_cosine():
+    x = properr.uval(0.0, 1.0)
+    y = properr.cos(x)
+
+    assert properr.nominal(y) == 1.0
+    assert properr.stddev(y) == 0.0


### PR DESCRIPTION
## Summary
- implement cosine operation for uncertain values in Rust and Python
- export new function in Python bindings
- test cosine propagation in Rust and Python
- document cosine support in README

## Testing
- `cargo test`
- `maturin build -q`
- `pip install target/wheels/properr-0.1.0-cp312-cp312-manylinux_2_34_x86_64.whl`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688108218d9883298bf796c8b3aa724b