### PR TITLE
Add exponential propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,5 @@ assert z.nominal() == 5.0
 - Propagation through the sine function
 - Propagation through the cosine function
 - Propagation through the square root function
+- Propagation through the exponential function
 - Shared Rust and Python APIs for high performance

--- a/properr/__init__.py
+++ b/properr/__init__.py
@@ -9,7 +9,17 @@ nominal = _rust.nominal
 stddev = _rust.stddev
 sin = _rust.sin
 cos = _rust.cos
+exp = _rust.exp
 sqrt = _rust.sqrt
 UncertainValue = _rust.UncertainValue
 
-__all__ = ["uval", "nominal", "stddev", "sin", "cos", "sqrt", "UncertainValue"]
+__all__ = [
+    "uval",
+    "nominal",
+    "stddev",
+    "sin",
+    "cos",
+    "exp",
+    "sqrt",
+    "UncertainValue",
+]

--- a/tests/rust.rs
+++ b/tests/rust.rs
@@ -40,3 +40,11 @@ fn sqrt_propagates_uncertainty() {
     // derivative 1/(2*sqrt(4)) = 1/4 -> variance = (0.5^2) * (1/4)^2 = 0.015625
     assert!((y.stddev() - 0.125).abs() < 1e-12);
 }
+
+#[test]
+fn exp_propagates_uncertainty() {
+    let x = UncertainValue::new(1.0, 0.1);
+    let y = x.exp();
+    assert!((y.nominal() - 2.718281828459045).abs() < 1e-12);
+    assert!((y.stddev() - 0.27182818284590454).abs() < 1e-12);
+}

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -10,12 +10,12 @@ def test_uncertain_arithmetic():
     z2 = x - x
 
     assert properr.nominal(z) == 0.0
-    assert properr.stddev(z) == pytest.approx(2 ** 0.5)
+    assert properr.stddev(z) == pytest.approx(2**0.5)
     assert properr.stddev(z2) == 0.0
 
     # object methods mirror the module-level helpers
     assert z.nominal() == 0.0
-    assert z.stddev() == pytest.approx(2 ** 0.5)
+    assert z.stddev() == pytest.approx(2**0.5)
 
 
 def test_uncertain_multiplication():
@@ -38,7 +38,7 @@ def test_uncertain_division():
     z2 = x / x
 
     assert properr.nominal(z) == 5.0
-    assert properr.stddev(z) == pytest.approx(0.5 ** 0.5)
+    assert properr.stddev(z) == pytest.approx(0.5**0.5)
     assert properr.nominal(z2) == 1.0
     assert properr.stddev(z2) == 0.0
 
@@ -65,3 +65,12 @@ def test_uncertain_sqrt():
 
     assert properr.nominal(y) == 2.0
     assert properr.stddev(y) == pytest.approx(0.125)
+
+
+def test_uncertain_exp():
+    x = properr.uval(1.0, 0.1)
+    y = properr.exp(x)
+
+    assert properr.nominal(y) == pytest.approx(2.718281828459045)
+    # derivative is e^x -> variance = (e^1 * 0.1)^2 = (0.2718281828)^2
+    assert properr.stddev(y) == pytest.approx((2.718281828459045 * 0.1))


### PR DESCRIPTION
## Summary
- implement `exp` for uncertain values in Rust and Python
- expose `exp` in the Python API
- document the new capability
- test exponential propagation from both languages

## Testing
- `pip install -e .[test]`
- `pytest -q`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68810b8aa1a083299a6a8881f014b8bf