### PR TITLE
Implement uncertain_function decorator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,6 @@ stddev(z)                 # ~1.414
 
 Optional extensions:
 
-* `@uncertain_function` decorator for black-box propagation
 * Pretty-printing for Jupyter
 
 ---

--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ assert z.nominal() == 5.0
 - Shared Rust and Python APIs for high performance
 - Creation of arrays of `UncertainValue` instances with `uvals`
 - NumPy ufunc integration for arithmetic and math functions
+- Decorator for black-box Python functions with `@uncertain_function`

--- a/properr/__init__.py
+++ b/properr/__init__.py
@@ -15,6 +15,7 @@ cos = _rust.cos
 exp = _rust.exp
 ln = _rust.ln
 sqrt = _rust.sqrt
+_from_parts = _rust.from_parts
 UncertainValue = _rust.UncertainValue
 
 __all__ = [
@@ -30,4 +31,46 @@ __all__ = [
     "ln",
     "sqrt",
     "UncertainValue",
+    "uncertain_function",
 ]
+
+
+def uncertain_function(func, *, epsilon=1e-8):
+    """Decorate a plain Python function for uncertainty propagation.
+
+    The wrapped function is evaluated on the nominal values of any
+    ``UncertainValue`` arguments and uses finite differences to
+    approximate partial derivatives. These derivatives are combined with
+    the derivatives of the inputs so that correlations are preserved.
+    """
+
+    def wrapper(*args):
+        nominals = []
+        deriv_maps = []
+        for a in args:
+            if isinstance(a, UncertainValue):
+                nominals.append(a.nominal())
+                deriv_maps.append(a._derivatives())
+            else:
+                nominals.append(a)
+                deriv_maps.append(None)
+
+        result_nom = func(*nominals)
+
+        out: dict[int, float] = {}
+        for i, dmap in enumerate(deriv_maps):
+            if dmap is None:
+                continue
+            plus = nominals.copy()
+            minus = nominals.copy()
+            plus[i] += epsilon
+            minus[i] -= epsilon
+            f_plus = func(*plus)
+            f_minus = func(*minus)
+            partial = (f_plus - f_minus) / (2 * epsilon)
+            for vid, d in dmap.items():
+                out[vid] = out.get(vid, 0.0) + partial * d
+
+        return _from_parts(result_nom, out)
+
+    return wrapper

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,13 @@ impl UncertainValue {
         }
     }
 
+    /// Create an uncertain value from a nominal and a derivative map. This is
+    /// primarily used by higher level helpers that construct new values from
+    /// externally computed derivatives.
+    pub fn from_parts(nominal: f64, derivatives: HashMap<u64, f64>) -> Self {
+        UncertainValue { nominal, derivatives }
+    }
+
     fn combine(
         left: &HashMap<u64, f64>,
         right: &HashMap<u64, f64>,
@@ -311,6 +318,15 @@ pub fn sqrt(v: &UncertainValue) -> UncertainValue {
     v.sqrt()
 }
 
+/// Construct an uncertain value from a nominal value and a derivative map
+#[cfg_attr(feature = "python", pyfunction)]
+pub fn from_parts(
+    nominal: f64,
+    derivatives: HashMap<u64, f64>,
+) -> UncertainValue {
+    UncertainValue::from_parts(nominal, derivatives)
+}
+
 /// Create multiple uncertain values from vectors of nominals and sigmas
 #[cfg_attr(feature = "python", pyfunction)]
 pub fn uvals(nominals: Vec<f64>, sigmas: Vec<f64>) -> Vec<UncertainValue> {
@@ -345,6 +361,11 @@ impl UncertainValue {
     #[pyo3(name = "stddev")]
     fn py_stddev(&self) -> f64 {
         self.stddev()
+    }
+
+    #[pyo3(name = "_derivatives")]
+    fn py_derivatives(&self) -> HashMap<u64, f64> {
+        self.derivatives.clone()
     }
 
     fn __add__(&self, other: &UncertainValue) -> UncertainValue {
@@ -469,6 +490,7 @@ fn _properr(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(exp, m)?)?;
     m.add_function(wrap_pyfunction!(ln, m)?)?;
     m.add_function(wrap_pyfunction!(sqrt, m)?)?;
+    m.add_function(wrap_pyfunction!(from_parts, m)?)?;
     m.add_class::<UncertainValue>()?;
     Ok(())
 }

--- a/tests/test_uncertain_function.py
+++ b/tests/test_uncertain_function.py
@@ -1,0 +1,17 @@
+import math
+import properr
+import pytest
+
+@properr.uncertain_function
+def f(x, y):
+    return math.sin(x) + y * y
+
+
+def test_decorator_nominal_and_stddev():
+    x = properr.uval(0.0, 1.0)
+    y = properr.uval(3.0, 0.5)
+    z = f(x, y)
+
+    assert properr.nominal(z) == pytest.approx(math.sin(0.0) + 9.0)
+    expected_sigma = (1.0 ** 2 * 1.0 ** 2 + (2 * 3.0) ** 2 * 0.5 ** 2) ** 0.5
+    assert properr.stddev(z) == pytest.approx(expected_sigma)


### PR DESCRIPTION
## Summary
- add `uncertain_function` decorator for black-box Python functions
- expose derivative maps and helper constructor in Rust
- document the new decorator in README
- remove the decorator from AGENTS todo list
- test the decorator

## Testing
- `cargo test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688148b8b7608329aa7db584b90d991a