### PR TITLE
Fix Read the Docs Rust version config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-    rust: "stable"
+    rust: "latest"
 
 python:
   install:


### PR DESCRIPTION
## Summary
- update rust toolchain to `latest` for Read the Docs builds

## Testing
- `cargo test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889856c67e48329891f245f56a511bd