### PR TITLE
Fix RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,8 +8,8 @@ build:
 
 python:
   install:
-    - path: .
-      editable: true
+    - method: pip
+      path: .
       extra_requirements:
         - test
     - requirements: docs/requirements.txt


### PR DESCRIPTION
## Summary
- remove unsupported `editable` option from `.readthedocs.yaml`
- specify pip as the install method

## Testing
- `pytest -q`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688a12685868832991a7546bbe10905e